### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.py.yml
+++ b/.github/workflows/test.py.yml
@@ -1,4 +1,6 @@
 name: Test coverage report
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/ONSdigital/blaise-editing-functions/security/code-scanning/6](https://github.com/ONSdigital/blaise-editing-functions/security/code-scanning/6)

You should add a `permissions` block at the root of the workflow (directly below the workflow `name:` and before `on:`) to set `permissions: contents: read` for all jobs by default. This follows the principle of least privilege and does not change the existing functionality. You do not need to add the block to each job separately unless some jobs need different permissions, which they currently do not. No other changes or imports are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
